### PR TITLE
fix: streamed response tool call without arguments

### DIFF
--- a/src/Responses/Chat/CreateStreamedResponseToolCallFunction.php
+++ b/src/Responses/Chat/CreateStreamedResponseToolCallFunction.php
@@ -18,7 +18,7 @@ final class CreateStreamedResponseToolCallFunction
     {
         return new self(
             $attributes['name'] ?? null,
-            $attributes['arguments'],
+            $attributes['arguments'] ?? '',
         );
     }
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

With some OpenAI "compatible" servers like [VLLM](https://github.com/vllm-project/vllm) we may have delta tools calls without the `arguments` attribute like this:

```
data: {"id":"chatcmpl-996b0e04-7602-4c12-ac19-2dc1c243a6d5","object":"chat.completion.chunk","created":1751620274,"model":"llama4","choices":[{"index":0,"delta":{"tool_calls":[{"id":"InRVNk0Ic","type":"function","index":0,"function":{"name":"get_weather"}}]}}]}
```
